### PR TITLE
Asyncify the APIs

### DIFF
--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -5,14 +5,16 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.70"
+futures = "0.3.28"
 parking_lot = "0.12.1"
 thiserror = "1.0.40"
 tracing = "0.1.37"
 
 [dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.4", features = ["html_reports", "async", "async_futures"] }
 pprof = { version = "0.11.1", features = ["criterion", "flamegraph"] }
 shuttle = "0.6.0"
+tokio = { version = "1.27.0", features = ["full"] }
 tracing-subscriber = "0"
 tracing-test = "0"
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.70"
+async-trait = "0.1.68"
 futures = "0.3.28"
-parking_lot = "0.12.1"
 thiserror = "1.0.40"
 tracing = "0.1.37"
+tokio = { version = "1.27.0", features = ["full"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports", "async", "async_futures"] }
@@ -17,7 +18,13 @@ shuttle = "0.6.0"
 tokio = { version = "1.27.0", features = ["full"] }
 tracing-subscriber = "0"
 tracing-test = "0"
+mvcc-rs = { path = ".", features = ["tokio"] }
 
 [[bench]]
 name = "my_benchmark"
 harness = false
+
+[features]
+default = []
+full = ["tokio"]
+tokio = ["dep:tokio"]

--- a/database/benches/my_benchmark.rs
+++ b/database/benches/my_benchmark.rs
@@ -9,7 +9,7 @@ fn bench(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1));
 
     let clock = LocalClock::default();
-    let db = Database::new(clock);
+    let db = Database::<LocalClock, tokio::sync::Mutex<_>>::new(clock);
     group.bench_function("begin_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             db.begin_tx().await;
@@ -17,7 +17,7 @@ fn bench(c: &mut Criterion) {
     });
 
     let clock = LocalClock::default();
-    let db = Database::new(clock);
+    let db = Database::<LocalClock, tokio::sync::Mutex<_>>::new(clock);
     group.bench_function("begin_tx + rollback_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             let tx_id = db.begin_tx().await;
@@ -26,7 +26,7 @@ fn bench(c: &mut Criterion) {
     });
 
     let clock = LocalClock::default();
-    let db = Database::new(clock);
+    let db = Database::<LocalClock, tokio::sync::Mutex<_>>::new(clock);
     group.bench_function("begin_tx + commit_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             let tx_id = db.begin_tx().await;
@@ -35,7 +35,7 @@ fn bench(c: &mut Criterion) {
     });
 
     let clock = LocalClock::default();
-    let db = Database::new(clock);
+    let db = Database::<LocalClock, tokio::sync::Mutex<_>>::new(clock);
     group.bench_function("begin_tx-read-commit_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             let tx_id = db.begin_tx().await;
@@ -45,7 +45,7 @@ fn bench(c: &mut Criterion) {
     });
 
     let clock = LocalClock::default();
-    let db = Database::new(clock);
+    let db = Database::<LocalClock, tokio::sync::Mutex<_>>::new(clock);
     group.bench_function("begin_tx-update-commit_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             let tx_id = db.begin_tx().await;
@@ -63,7 +63,7 @@ fn bench(c: &mut Criterion) {
     });
 
     let clock = LocalClock::default();
-    let db = Database::new(clock);
+    let db = Database::<LocalClock, tokio::sync::Mutex<_>>::new(clock);
     let tx = futures::executor::block_on(db.begin_tx());
     futures::executor::block_on(db.insert(
         tx,
@@ -80,7 +80,7 @@ fn bench(c: &mut Criterion) {
     });
 
     let clock = LocalClock::default();
-    let db = Database::new(clock);
+    let db = Database::<LocalClock, tokio::sync::Mutex<_>>::new(clock);
     let tx = futures::executor::block_on(db.begin_tx());
     futures::executor::block_on(db.insert(
         tx,

--- a/database/benches/my_benchmark.rs
+++ b/database/benches/my_benchmark.rs
@@ -1,3 +1,4 @@
+use criterion::async_executor::FuturesExecutor;
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use mvcc_rs::clock::LocalClock;
 use mvcc_rs::database::{Database, Row};
@@ -10,44 +11,44 @@ fn bench(c: &mut Criterion) {
     let clock = LocalClock::default();
     let db = Database::new(clock);
     group.bench_function("begin_tx", |b| {
-        b.iter(|| {
-            db.begin_tx();
+        b.to_async(FuturesExecutor).iter(|| async {
+            db.begin_tx().await;
         })
     });
 
     let clock = LocalClock::default();
     let db = Database::new(clock);
     group.bench_function("begin_tx + rollback_tx", |b| {
-        b.iter(|| {
-            let tx_id = db.begin_tx();
-            db.rollback_tx(tx_id)
+        b.to_async(FuturesExecutor).iter(|| async {
+            let tx_id = db.begin_tx().await;
+            db.rollback_tx(tx_id).await
         })
     });
 
     let clock = LocalClock::default();
     let db = Database::new(clock);
     group.bench_function("begin_tx + commit_tx", |b| {
-        b.iter(|| {
-            let tx_id = db.begin_tx();
-            db.commit_tx(tx_id)
+        b.to_async(FuturesExecutor).iter(|| async {
+            let tx_id = db.begin_tx().await;
+            db.commit_tx(tx_id).await
         })
     });
 
     let clock = LocalClock::default();
     let db = Database::new(clock);
     group.bench_function("begin_tx-read-commit_tx", |b| {
-        b.iter(|| {
-            let tx_id = db.begin_tx();
-            db.read(tx_id, 1).unwrap();
-            db.commit_tx(tx_id)
+        b.to_async(FuturesExecutor).iter(|| async {
+            let tx_id = db.begin_tx().await;
+            db.read(tx_id, 1).await.unwrap();
+            db.commit_tx(tx_id).await
         })
     });
 
     let clock = LocalClock::default();
     let db = Database::new(clock);
     group.bench_function("begin_tx-update-commit_tx", |b| {
-        b.iter(|| {
-            let tx_id = db.begin_tx();
+        b.to_async(FuturesExecutor).iter(|| async {
+            let tx_id = db.begin_tx().await;
             db.update(
                 tx_id,
                 Row {
@@ -55,41 +56,42 @@ fn bench(c: &mut Criterion) {
                     data: "World".to_string(),
                 },
             )
+            .await
             .unwrap();
-            db.commit_tx(tx_id)
+            db.commit_tx(tx_id).await
         })
     });
 
     let clock = LocalClock::default();
     let db = Database::new(clock);
-    let tx = db.begin_tx();
-    db.insert(
+    let tx = futures::executor::block_on(db.begin_tx());
+    futures::executor::block_on(db.insert(
         tx,
         Row {
             id: 1,
             data: "Hello".to_string(),
         },
-    )
+    ))
     .unwrap();
     group.bench_function("read", |b| {
-        b.iter(|| {
-            db.read(tx, 1).unwrap();
+        b.to_async(FuturesExecutor).iter(|| async {
+            db.read(tx, 1).await.unwrap();
         })
     });
 
     let clock = LocalClock::default();
     let db = Database::new(clock);
-    let tx = db.begin_tx();
-    db.insert(
+    let tx = futures::executor::block_on(db.begin_tx());
+    futures::executor::block_on(db.insert(
         tx,
         Row {
             id: 1,
             data: "Hello".to_string(),
         },
-    )
+    ))
     .unwrap();
     group.bench_function("update", |b| {
-        b.iter(|| {
+        b.to_async(FuturesExecutor).iter(|| async {
             db.update(
                 tx,
                 Row {
@@ -97,6 +99,7 @@ fn bench(c: &mut Criterion) {
                     data: "World".to_string(),
                 },
             )
+            .await
             .unwrap();
         })
     });

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -34,3 +34,4 @@
 pub mod clock;
 pub mod database;
 pub mod errors;
+pub mod sync;

--- a/database/src/sync.rs
+++ b/database/src/sync.rs
@@ -1,0 +1,43 @@
+#[async_trait::async_trait]
+pub trait AsyncMutex {
+    type Inner;
+    type Guard<'a>: std::ops::DerefMut<Target = Self::Inner>
+    where
+        Self: 'a,
+        Self::Inner: 'a;
+
+    fn new(inner: Self::Inner) -> Self;
+
+    async fn lock<'a>(&'a self) -> Self::Guard<'a>;
+}
+
+#[async_trait::async_trait]
+impl<T: Send> AsyncMutex for std::sync::Mutex<T> {
+    type Inner = T;
+    type Guard<'a> = std::sync::MutexGuard<'a, T> where T: 'a;
+
+    fn new(inner: Self::Inner) -> Self {
+        Self::new(inner)
+    }
+
+    async fn lock<'a>(&'a self) -> Self::Guard<'a> {
+        self.lock().unwrap()
+    }
+}
+
+#[cfg(feature = "tokio")]
+mod tokio_mutex {
+    #[async_trait::async_trait]
+    impl<T: Send> super::AsyncMutex for tokio::sync::Mutex<T> {
+        type Inner = T;
+        type Guard<'a> = tokio::sync::MutexGuard<'a, T> where T: 'a;
+
+        fn new(inner: Self::Inner) -> Self {
+            Self::new(inner)
+        }
+
+        async fn lock<'a>(&'a self) -> Self::Guard<'a> {
+            self.lock().await
+        }
+    }
+}

--- a/database/tests/concurrency_test.rs
+++ b/database/tests/concurrency_test.rs
@@ -10,7 +10,7 @@ fn test_non_overlapping_concurrent_inserts() {
     // Two threads insert to the database concurrently using non-overlapping
     // row IDs.
     let clock = LocalClock::default();
-    let db = Arc::new(Database::new(clock));
+    let db = Arc::new(Database::<LocalClock, tokio::sync::Mutex<_>>::new(clock));
     let ids = Arc::new(AtomicU64::new(0));
     shuttle::check_random(
         move || {

--- a/database/tests/concurrency_test.rs
+++ b/database/tests/concurrency_test.rs
@@ -18,36 +18,40 @@ fn test_non_overlapping_concurrent_inserts() {
                 let db = db.clone();
                 let ids = ids.clone();
                 thread::spawn(move || {
-                    let tx = db.begin_tx();
-                    let id = ids.fetch_add(1, Ordering::SeqCst);
-                    let row = Row {
-                        id,
-                        data: "Hello".to_string(),
-                    };
-                    db.insert(tx, row.clone()).unwrap();
-                    db.commit_tx(tx).unwrap();
-                    let tx = db.begin_tx();
-                    let committed_row = db.read(tx, id).unwrap();
-                    db.commit_tx(tx).unwrap();
-                    assert_eq!(committed_row, Some(row));
+                    shuttle::future::block_on(async move {
+                        let tx = db.begin_tx().await;
+                        let id = ids.fetch_add(1, Ordering::SeqCst);
+                        let row = Row {
+                            id,
+                            data: "Hello".to_string(),
+                        };
+                        db.insert(tx, row.clone()).await.unwrap();
+                        db.commit_tx(tx).await.unwrap();
+                        let tx = db.begin_tx().await;
+                        let committed_row = db.read(tx, id).await.unwrap();
+                        db.commit_tx(tx).await.unwrap();
+                        assert_eq!(committed_row, Some(row));
+                    })
                 });
             }
             {
                 let db = db.clone();
                 let ids = ids.clone();
                 thread::spawn(move || {
-                    let tx = db.begin_tx();
-                    let id = ids.fetch_add(1, Ordering::SeqCst);
-                    let row = Row {
-                        id,
-                        data: "World".to_string(),
-                    };
-                    db.insert(tx, row.clone()).unwrap();
-                    db.commit_tx(tx).unwrap();
-                    let tx = db.begin_tx();
-                    let committed_row = db.read(tx, id).unwrap();
-                    db.commit_tx(tx).unwrap();
-                    assert_eq!(committed_row, Some(row));
+                    shuttle::future::block_on(async move {
+                        let tx = db.begin_tx().await;
+                        let id = ids.fetch_add(1, Ordering::SeqCst);
+                        let row = Row {
+                            id,
+                            data: "World".to_string(),
+                        };
+                        db.insert(tx, row.clone()).await.unwrap();
+                        db.commit_tx(tx).await.unwrap();
+                        let tx = db.begin_tx().await;
+                        let committed_row = db.read(tx, id).await.unwrap();
+                        db.commit_tx(tx).await.unwrap();
+                        assert_eq!(committed_row, Some(row));
+                    });
                 });
             }
         },


### PR DESCRIPTION
In order to prepare for #3, the APIs are made asynchronous. It also applies to tests and benches.