### PR TITLE
Fix MVCCDatabaseInsert() type signature

### DIFF
--- a/bindings/c/include/mvcc.h
+++ b/bindings/c/include/mvcc.h
@@ -20,7 +20,7 @@ MVCCDatabaseRef MVCCDatabaseOpen(const char *path);
 
 void MVCCDatabaseClose(MVCCDatabaseRef db);
 
-MVCCError MVCCDatabaseInsert(MVCCDatabaseRef db, uint64_t id, const uint8_t *value_ptr, uintptr_t value_len);
+MVCCError MVCCDatabaseInsert(MVCCDatabaseRef db, uint64_t id, const void *value_ptr, uintptr_t value_len);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -62,11 +62,11 @@ pub unsafe extern "C" fn MVCCDatabaseClose(db: MVCCDatabaseRef) {
 pub unsafe extern "C" fn MVCCDatabaseInsert(
     db: MVCCDatabaseRef,
     id: u64,
-    value_ptr: *const u8,
+    value_ptr: *const std::ffi::c_void,
     value_len: usize,
 ) -> MVCCError {
     let db = db.get_ref();
-    let value = std::slice::from_raw_parts(value_ptr, value_len);
+    let value = std::slice::from_raw_parts(value_ptr as *const u8, value_len);
     let data = match std::str::from_utf8(value) {
         Ok(value) => value.to_string(),
         Err(_) => {


### PR DESCRIPTION
Values are opaque blobs so use "const void *" for C callers.