### PR TITLE
bindings: expose reading from the database

### DIFF
--- a/bindings/c/include/mvcc.h
+++ b/bindings/c/include/mvcc.h
@@ -5,6 +5,7 @@
 
 typedef enum {
   MVCC_OK = 0,
+  MVCC_IO_ERROR_READ = 266,
   MVCC_IO_ERROR_WRITE = 778,
 } MVCCError;
 
@@ -21,6 +22,10 @@ MVCCDatabaseRef MVCCDatabaseOpen(const char *path);
 void MVCCDatabaseClose(MVCCDatabaseRef db);
 
 MVCCError MVCCDatabaseInsert(MVCCDatabaseRef db, uint64_t id, const void *value_ptr, uintptr_t value_len);
+
+MVCCError MVCCDatabaseRead(MVCCDatabaseRef db, uint64_t id, char **value_ptr, int64_t *value_len);
+
+void MVCCFreeStr(void *ptr);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/bindings/c/src/errors.rs
+++ b/bindings/c/src/errors.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 pub enum MVCCError {
     MVCC_OK = 0,
+    MVCC_IO_ERROR_READ = 266,
     MVCC_IO_ERROR_WRITE = 778,
 }


### PR DESCRIPTION
The results are returned as a CString for now.