### PR TITLE
mvcc: switch to (table_id, row_id) for row ids

### DIFF
--- a/bindings/c/include/mvcc.h
+++ b/bindings/c/include/mvcc.h
@@ -25,13 +25,21 @@ MVCCDatabaseRef MVCCDatabaseOpen(const char *path);
 
 void MVCCDatabaseClose(MVCCDatabaseRef db);
 
-MVCCError MVCCDatabaseInsert(MVCCDatabaseRef db, uint64_t id, const void *value_ptr, uintptr_t value_len);
+MVCCError MVCCDatabaseInsert(MVCCDatabaseRef db,
+                             uint64_t table_id,
+                             uint64_t row_id,
+                             const void *value_ptr,
+                             uintptr_t value_len);
 
-MVCCError MVCCDatabaseRead(MVCCDatabaseRef db, uint64_t id, uint8_t **value_ptr, int64_t *value_len);
+MVCCError MVCCDatabaseRead(MVCCDatabaseRef db,
+                           uint64_t table_id,
+                           uint64_t row_id,
+                           uint8_t **value_ptr,
+                           int64_t *value_len);
 
 void MVCCFreeStr(void *ptr);
 
-MVCCScanCursorRef MVCCScanCursorOpen(MVCCDatabaseRef db);
+MVCCScanCursorRef MVCCScanCursorOpen(MVCCDatabaseRef db, uint64_t table_id);
 
 void MVCCScanCursorClose(MVCCScanCursorRef cursor);
 

--- a/mvcc-rs/benches/my_benchmark.rs
+++ b/mvcc-rs/benches/my_benchmark.rs
@@ -1,7 +1,7 @@
 use criterion::async_executor::FuturesExecutor;
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use mvcc_rs::clock::LocalClock;
-use mvcc_rs::database::{Database, Row};
+use mvcc_rs::database::{Database, Row, RowID};
 use pprof::criterion::{Output, PProfProfiler};
 
 fn bench_db() -> Database<
@@ -47,7 +47,15 @@ fn bench(c: &mut Criterion) {
     group.bench_function("begin_tx-read-commit_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             let tx_id = db.begin_tx().await;
-            db.read(tx_id, 1).await.unwrap();
+            db.read(
+                tx_id,
+                RowID {
+                    table_id: 1,
+                    row_id: 1,
+                },
+            )
+            .await
+            .unwrap();
             db.commit_tx(tx_id).await
         })
     });
@@ -59,7 +67,10 @@ fn bench(c: &mut Criterion) {
             db.update(
                 tx_id,
                 Row {
-                    id: 1,
+                    id: RowID {
+                        table_id: 1,
+                        row_id: 1,
+                    },
                     data: "World".to_string(),
                 },
             )
@@ -74,14 +85,25 @@ fn bench(c: &mut Criterion) {
     futures::executor::block_on(db.insert(
         tx,
         Row {
-            id: 1,
+            id: RowID {
+                table_id: 1,
+                row_id: 1,
+            },
             data: "Hello".to_string(),
         },
     ))
     .unwrap();
     group.bench_function("read", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
-            db.read(tx, 1).await.unwrap();
+            db.read(
+                tx,
+                RowID {
+                    table_id: 1,
+                    row_id: 1,
+                },
+            )
+            .await
+            .unwrap();
         })
     });
 
@@ -90,7 +112,10 @@ fn bench(c: &mut Criterion) {
     futures::executor::block_on(db.insert(
         tx,
         Row {
-            id: 1,
+            id: RowID {
+                table_id: 1,
+                row_id: 1,
+            },
             data: "Hello".to_string(),
         },
     ))
@@ -100,7 +125,10 @@ fn bench(c: &mut Criterion) {
             db.update(
                 tx,
                 Row {
-                    id: 1,
+                    id: RowID {
+                        table_id: 1,
+                        row_id: 1,
+                    },
                     data: "World".to_string(),
                 },
             )

--- a/mvcc-rs/tests/concurrency_test.rs
+++ b/mvcc-rs/tests/concurrency_test.rs
@@ -1,5 +1,5 @@
 use mvcc_rs::clock::LocalClock;
-use mvcc_rs::database::{Database, Row};
+use mvcc_rs::database::{Database, Row, RowID};
 use shuttle::sync::atomic::AtomicU64;
 use shuttle::sync::Arc;
 use shuttle::thread;
@@ -22,6 +22,10 @@ fn test_non_overlapping_concurrent_inserts() {
                     shuttle::future::block_on(async move {
                         let tx = db.begin_tx().await;
                         let id = ids.fetch_add(1, Ordering::SeqCst);
+                        let id = RowID {
+                            table_id: 1,
+                            row_id: id,
+                        };
                         let row = Row {
                             id,
                             data: "Hello".to_string(),
@@ -42,6 +46,10 @@ fn test_non_overlapping_concurrent_inserts() {
                     shuttle::future::block_on(async move {
                         let tx = db.begin_tx().await;
                         let id = ids.fetch_add(1, Ordering::SeqCst);
+                        let id = RowID {
+                            table_id: 1,
+                            row_id: id,
+                        };
                         let row = Row {
                             id,
                             data: "World".to_string(),


### PR DESCRIPTION
With that, we're able to easily distinguish rows from different tables.