### PR TITLE
treewide: drop storage trait

### DIFF
--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -12,7 +12,7 @@ cbindgen = "0.24.0"
 
 [dependencies]
 base64 = "0.21.0"
-mvcc-rs = { path = "../../mvcc-rs", features = ["tokio"] }
+mvcc-rs = { path = "../../mvcc-rs" }
 tokio = { version = "1.27.0", features = ["full", "parking_lot"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0" }

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -12,13 +12,10 @@ use types::{DbContext, MVCCDatabaseRef, MVCCScanCursorRef, ScanCursorContext};
 type Clock = clock::LocalClock;
 
 /// cbindgen:ignore
-type Storage = persistent_storage::JsonOnDisk;
+type Db = database::Database<Clock>;
 
 /// cbindgen:ignore
-type Db = database::Database<Clock, Storage>;
-
-/// cbindgen:ignore
-type ScanCursor = cursor::ScanCursor<'static, Clock, Storage>;
+type ScanCursor = cursor::ScanCursor<'static, Clock>;
 
 static INIT_RUST_LOG: std::sync::Once = std::sync::Once::new();
 
@@ -40,7 +37,7 @@ pub unsafe extern "C" fn MVCCDatabaseOpen(path: *const std::ffi::c_char) -> MVCC
         }
     };
     tracing::debug!("mvccrs: opening persistent storage at {path}");
-    let storage = crate::persistent_storage::JsonOnDisk::new(path);
+    let storage = crate::persistent_storage::Storage::new_json_on_disk(path);
     let db = Db::new(clock, storage);
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let ctx = DbContext { db, runtime };

--- a/mvcc-rs/Cargo.toml
+++ b/mvcc-rs/Cargo.toml
@@ -5,12 +5,11 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.70"
-async-trait = "0.1.68"
 futures = "0.3.28"
 thiserror = "1.0.40"
 tracing = "0.1.37"
-tokio = { version = "1.27.0", features = ["full", "parking_lot"], optional = true }
-tokio-stream = { version = "0.1.12", optional = true, features = ["io-util"] }
+tokio = { version = "1.27.0", features = ["full", "parking_lot"] }
+tokio-stream = { version = "0.1.12", features = ["io-util"] }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 pin-project = "1.0.12"
@@ -21,10 +20,9 @@ base64 = "0.21.0"
 criterion = { version = "0.4", features = ["html_reports", "async", "async_futures"] }
 pprof = { version = "0.11.1", features = ["criterion", "flamegraph"] }
 shuttle = "0.6.0"
-tokio = { version = "1.27.0", features = ["full", "parking_lot"] }
 tracing-subscriber = "0"
 tracing-test = "0"
-mvcc-rs = { path = ".", features = ["tokio"] }
+mvcc-rs = { path = "." }
 
 [[bench]]
 name = "my_benchmark"
@@ -32,6 +30,4 @@ harness = false
 
 [features]
 default = []
-full = ["tokio"]
-c_bindings = ["tokio", "dep:tracing-subscriber"]
-tokio = ["dep:tokio", "dep:tokio-stream"]
+c_bindings = ["dep:tracing-subscriber"]

--- a/mvcc-rs/benches/my_benchmark.rs
+++ b/mvcc-rs/benches/my_benchmark.rs
@@ -4,12 +4,9 @@ use mvcc_rs::clock::LocalClock;
 use mvcc_rs::database::{Database, Row, RowID};
 use pprof::criterion::{Output, PProfProfiler};
 
-fn bench_db() -> Database<
-    LocalClock,
-    mvcc_rs::persistent_storage::Noop,
-> {
+fn bench_db() -> Database<LocalClock> {
     let clock = LocalClock::default();
-    let storage = mvcc_rs::persistent_storage::Noop {};
+    let storage = mvcc_rs::persistent_storage::Storage::new_noop();
     Database::new(clock, storage)
 }
 

--- a/mvcc-rs/src/cursor.rs
+++ b/mvcc-rs/src/cursor.rs
@@ -1,29 +1,16 @@
 use crate::clock::LogicalClock;
 use crate::database::{Database, Result, Row, RowID};
-use crate::persistent_storage::Storage;
 
 #[derive(Debug)]
-pub struct ScanCursor<
-    'a,
-    Clock: LogicalClock,
-    StorageImpl: Storage,
-> {
-    pub db: &'a Database<Clock, StorageImpl>,
+pub struct ScanCursor<'a, Clock: LogicalClock> {
+    pub db: &'a Database<Clock>,
     pub row_ids: Vec<RowID>,
     pub index: usize,
     tx_id: u64,
 }
 
-impl<
-        'a,
-        Clock: LogicalClock,
-        StorageImpl: Storage,
-    > ScanCursor<'a, Clock, StorageImpl>
-{
-    pub async fn new(
-        db: &'a Database<Clock, StorageImpl>,
-        table_id: u64,
-    ) -> Result<ScanCursor<'a, Clock, StorageImpl>> {
+impl<'a, Clock: LogicalClock> ScanCursor<'a, Clock> {
+    pub async fn new(db: &'a Database<Clock>, table_id: u64) -> Result<ScanCursor<'a, Clock>> {
         let tx_id = db.begin_tx().await;
         let row_ids = db.scan_row_ids_for_table(table_id).await?;
         Ok(Self {

--- a/mvcc-rs/tests/concurrency_test.rs
+++ b/mvcc-rs/tests/concurrency_test.rs
@@ -10,7 +10,7 @@ fn test_non_overlapping_concurrent_inserts() {
     // Two threads insert to the database concurrently using non-overlapping
     // row IDs.
     let clock = LocalClock::default();
-    let storage = mvcc_rs::persistent_storage::Noop {};
+    let storage = mvcc_rs::persistent_storage::Storage::new_noop();
     let db = Arc::new(Database::new(clock, storage));
     let ids = Arc::new(AtomicU64::new(0));
     shuttle::check_random(


### PR DESCRIPTION
We're good with an enum, and async_trait has a runtime cost we don't like.