### PR TITLE
bindings: split transcation begin from insert/read

### DIFF
--- a/bindings/c/include/mvcc.h
+++ b/bindings/c/include/mvcc.h
@@ -25,13 +25,21 @@ MVCCDatabaseRef MVCCDatabaseOpen(const char *path);
 
 void MVCCDatabaseClose(MVCCDatabaseRef db);
 
+uint64_t MVCCTransactionBegin(MVCCDatabaseRef db);
+
+MVCCError MVCCTransactionCommit(MVCCDatabaseRef db, uint64_t tx_id);
+
+MVCCError MVCCTransactionRollback(MVCCDatabaseRef db, uint64_t tx_id);
+
 MVCCError MVCCDatabaseInsert(MVCCDatabaseRef db,
+                             uint64_t tx_id,
                              uint64_t table_id,
                              uint64_t row_id,
                              const void *value_ptr,
                              uintptr_t value_len);
 
 MVCCError MVCCDatabaseRead(MVCCDatabaseRef db,
+                           uint64_t tx_id,
                            uint64_t table_id,
                            uint64_t row_id,
                            uint8_t **value_ptr,
@@ -39,7 +47,7 @@ MVCCError MVCCDatabaseRead(MVCCDatabaseRef db,
 
 void MVCCFreeStr(void *ptr);
 
-MVCCScanCursorRef MVCCScanCursorOpen(MVCCDatabaseRef db, uint64_t table_id);
+MVCCScanCursorRef MVCCScanCursorOpen(MVCCDatabaseRef db, uint64_t tx_id, uint64_t table_id);
 
 void MVCCScanCursorClose(MVCCScanCursorRef cursor);
 

--- a/mvcc-rs/src/cursor.rs
+++ b/mvcc-rs/src/cursor.rs
@@ -10,8 +10,11 @@ pub struct ScanCursor<'a, Clock: LogicalClock> {
 }
 
 impl<'a, Clock: LogicalClock> ScanCursor<'a, Clock> {
-    pub async fn new(db: &'a Database<Clock>, table_id: u64) -> Result<ScanCursor<'a, Clock>> {
-        let tx_id = db.begin_tx().await;
+    pub async fn new(
+        db: &'a Database<Clock>,
+        tx_id: u64,
+        table_id: u64,
+    ) -> Result<ScanCursor<'a, Clock>> {
         let row_ids = db.scan_row_ids_for_table(table_id).await?;
         Ok(Self {
             db,
@@ -37,7 +40,7 @@ impl<'a, Clock: LogicalClock> ScanCursor<'a, Clock> {
     }
 
     pub async fn close(self) -> Result<()> {
-        self.db.commit_tx(self.tx_id).await
+        Ok(())
     }
 
     pub fn forward(&mut self) -> bool {

--- a/mvcc-rs/src/database.rs
+++ b/mvcc-rs/src/database.rs
@@ -137,7 +137,7 @@ impl<Clock: LogicalClock> Database<Clock> {
             rows: RefCell::new(BTreeMap::new()),
             txs: RefCell::new(HashMap::new()),
             tx_timestamps: RefCell::new(BTreeMap::new()),
-            tx_ids: AtomicU64::new(0),
+            tx_ids: AtomicU64::new(1), // let's reserve transaction 0 for special purposes
             clock,
             storage,
         };


### PR DESCRIPTION
libSQL expects to be able to begin/commit a transaction independently of reading or inserting data.