### PR TITLE
treewide: overhaul the API to be sync again

### DIFF
--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -13,7 +13,6 @@ cbindgen = "0.24.0"
 [dependencies]
 base64 = "0.21.0"
 mvcc-rs = { path = "../../mvcc-rs" }
-tokio = { version = "1.27.0", features = ["full", "parking_lot"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0" }
 

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -20,7 +20,7 @@ type ScanCursor = cursor::ScanCursor<'static, Clock>;
 
 static INIT_RUST_LOG: std::sync::Once = std::sync::Once::new();
 
-async fn storage_for(main_db_path: &str) -> database::Result<Storage> {
+fn storage_for(main_db_path: &str) -> database::Result<Storage> {
     // TODO: let's accept an URL instead of main_db_path here, so we can
     // pass custom S3 endpoints, options, etc.
     if cfg!(feature = "json_on_disk_storage") {
@@ -29,7 +29,8 @@ async fn storage_for(main_db_path: &str) -> database::Result<Storage> {
     }
     if cfg!(feature = "s3_storage") {
         tracing::info!("S3 storage for {main_db_path}");
-        return Storage::new_s3(s3::Options::with_create_bucket_if_not_exists(true)).await;
+        let options = s3::Options::with_create_bucket_if_not_exists(true);
+        return Storage::new_s3(options);
     }
     tracing::info!("No persistent storage for {main_db_path}");
     Ok(Storage::new_noop())
@@ -52,10 +53,9 @@ pub unsafe extern "C" fn MVCCDatabaseOpen(path: *const std::ffi::c_char) -> MVCC
             return MVCCDatabaseRef::null();
         }
     };
-    let runtime = tokio::runtime::Runtime::new().unwrap();
 
     tracing::debug!("mvccrs: opening persistent storage for {main_db_path}");
-    let storage = match runtime.block_on(storage_for(main_db_path)) {
+    let storage = match storage_for(main_db_path) {
         Ok(storage) => storage,
         Err(e) => {
             tracing::error!("Failed to open persistent storage: {e}");
@@ -64,11 +64,10 @@ pub unsafe extern "C" fn MVCCDatabaseOpen(path: *const std::ffi::c_char) -> MVCC
     };
     let db = Db::new(clock, storage);
 
-    runtime.block_on(db.recover()).ok();
+    db.recover().ok();
 
-    let ctx = DbContext { db, runtime };
-    let ctx = Box::leak(Box::new(ctx));
-    MVCCDatabaseRef::from(ctx)
+    let db = Box::leak(Box::new(DbContext { db }));
+    MVCCDatabaseRef::from(db)
 }
 
 #[no_mangle]
@@ -84,8 +83,7 @@ pub unsafe extern "C" fn MVCCDatabaseClose(db: MVCCDatabaseRef) {
 #[no_mangle]
 pub unsafe extern "C" fn MVCCTransactionBegin(db: MVCCDatabaseRef) -> u64 {
     let db = db.get_ref();
-    let (db, runtime) = (&db.db, &db.runtime);
-    let tx_id = runtime.block_on(async move { db.begin_tx().await });
+    let tx_id = db.begin_tx();
     tracing::debug!("MVCCTransactionBegin: {tx_id}");
     tx_id
 }
@@ -93,9 +91,8 @@ pub unsafe extern "C" fn MVCCTransactionBegin(db: MVCCDatabaseRef) -> u64 {
 #[no_mangle]
 pub unsafe extern "C" fn MVCCTransactionCommit(db: MVCCDatabaseRef, tx_id: u64) -> MVCCError {
     let db = db.get_ref();
-    let (db, runtime) = (&db.db, &db.runtime);
     tracing::debug!("MVCCTransactionCommit: {tx_id}");
-    match runtime.block_on(async move { db.commit_tx(tx_id).await }) {
+    match db.commit_tx(tx_id) {
         Ok(()) => MVCCError::MVCC_OK,
         Err(e) => {
             tracing::error!("MVCCTransactionCommit: {e}");
@@ -107,9 +104,8 @@ pub unsafe extern "C" fn MVCCTransactionCommit(db: MVCCDatabaseRef, tx_id: u64) 
 #[no_mangle]
 pub unsafe extern "C" fn MVCCTransactionRollback(db: MVCCDatabaseRef, tx_id: u64) -> MVCCError {
     let db = db.get_ref();
-    let (db, runtime) = (&db.db, &db.runtime);
     tracing::debug!("MVCCTransactionRollback: {tx_id}");
-    runtime.block_on(async move { db.rollback_tx(tx_id).await });
+    db.rollback_tx(tx_id);
     MVCCError::MVCC_OK
 }
 
@@ -132,11 +128,10 @@ pub unsafe extern "C" fn MVCCDatabaseInsert(
             general_purpose::STANDARD.encode(value)
         }
     };
-    let (db, runtime) = (&db.db, &db.runtime);
     let id = database::RowID { table_id, row_id };
     let row = database::Row { id, data };
     tracing::debug!("MVCCDatabaseInsert: {row:?}");
-    match runtime.block_on(async move { db.insert(tx_id, row).await }) {
+    match db.insert(tx_id, row) {
         Ok(_) => {
             tracing::debug!("MVCCDatabaseInsert: success");
             MVCCError::MVCC_OK
@@ -158,29 +153,24 @@ pub unsafe extern "C" fn MVCCDatabaseRead(
     value_len: *mut i64,
 ) -> MVCCError {
     let db = db.get_ref();
-    let (db, runtime) = (&db.db, &db.runtime);
 
-    match runtime.block_on(async move {
+    match {
         let id = database::RowID { table_id, row_id };
-        let maybe_row = db.read(tx_id, id).await?;
+        let maybe_row = db.read(tx_id, id);
         match maybe_row {
-            Some(row) => {
+            Ok(Some(row)) => {
                 tracing::debug!("Found row {row:?}");
                 let str_len = row.data.len() + 1;
-                let value = std::ffi::CString::new(row.data.as_bytes()).map_err(|e| {
-                    mvcc_rs::errors::DatabaseError::Io(format!(
-                        "Failed to transform read data into CString: {e}"
-                    ))
-                })?;
+                let value = std::ffi::CString::new(row.data.as_bytes()).unwrap_or_default();
                 unsafe {
                     *value_ptr = value.into_raw() as *mut u8;
                     *value_len = str_len as i64;
                 }
             }
-            None => unsafe { *value_len = -1 },
+            _ => unsafe { *value_len = -1 },
         };
         Ok::<(), mvcc_rs::errors::DatabaseError>(())
-    }) {
+    } {
         Ok(_) => {
             tracing::debug!("MVCCDatabaseRead: success");
             MVCCError::MVCC_OK
@@ -209,11 +199,8 @@ pub unsafe extern "C" fn MVCCScanCursorOpen(
     tracing::debug!("MVCCScanCursorOpen()");
     // Reference is transmuted to &'static in order to be able to pass the cursor back to C.
     // The contract with C is to never use a cursor after MVCCDatabaseClose() has been called.
-    let database = unsafe { std::mem::transmute::<&DbContext, &'static DbContext>(db.get_ref()) };
-    let (database, runtime) = (&database.db, &database.runtime);
-    match runtime
-        .block_on(async move { mvcc_rs::cursor::ScanCursor::new(database, tx_id, table_id).await })
-    {
+    let db = unsafe { std::mem::transmute::<&Db, &'static Db>(db.get_ref()) };
+    match mvcc_rs::cursor::ScanCursor::new(db, tx_id, table_id) {
         Ok(cursor) => {
             if cursor.is_empty() {
                 tracing::debug!("Cursor is empty");
@@ -223,7 +210,7 @@ pub unsafe extern "C" fn MVCCScanCursorOpen(
             }
             tracing::debug!("Cursor open: {cursor:?}");
             MVCCScanCursorRef {
-                ptr: Box::into_raw(Box::new(ScanCursorContext { cursor, db })),
+                ptr: Box::into_raw(Box::new(ScanCursorContext { cursor })),
             }
         }
         Err(e) => {
@@ -242,10 +229,8 @@ pub unsafe extern "C" fn MVCCScanCursorClose(cursor: MVCCScanCursorRef) {
         tracing::debug!("warning: `cursor` is null in MVCCScanCursorClose()");
         return;
     }
-    let cursor_ctx = unsafe { Box::from_raw(cursor.ptr) };
-    let db_context = cursor_ctx.db.clone();
-    let runtime = &db_context.get_ref().runtime;
-    runtime.block_on(async move { cursor_ctx.cursor.close().await.ok() });
+    let cursor = unsafe { Box::from_raw(cursor.ptr) }.cursor;
+    cursor.close().ok();
 }
 
 #[no_mangle]
@@ -259,31 +244,24 @@ pub unsafe extern "C" fn MVCCScanCursorRead(
         tracing::debug!("warning: `cursor` is null in MVCCScanCursorRead()");
         return MVCCError::MVCC_IO_ERROR_READ;
     }
-    let cursor_ctx = unsafe { &*cursor.ptr };
-    let runtime = &cursor_ctx.db.get_ref().runtime;
-    let cursor = &cursor_ctx.cursor;
+    let cursor = cursor.get_ref();
 
-    // TODO: deduplicate with MVCCDatabaseRead()
-    match runtime.block_on(async move {
-        let maybe_row = cursor.current_row().await?;
+    match {
+        let maybe_row = cursor.current_row();
         match maybe_row {
-            Some(row) => {
+            Ok(Some(row)) => {
                 tracing::debug!("Found row {row:?}");
                 let str_len = row.data.len() + 1;
-                let value = std::ffi::CString::new(row.data.as_bytes()).map_err(|e| {
-                    mvcc_rs::errors::DatabaseError::Io(format!(
-                        "Failed to transform read data into CString: {e}"
-                    ))
-                })?;
+                let value = std::ffi::CString::new(row.data.as_bytes()).unwrap_or_default();
                 unsafe {
                     *value_ptr = value.into_raw() as *mut u8;
                     *value_len = str_len as i64;
                 }
             }
-            None => unsafe { *value_len = -1 },
+            _ => unsafe { *value_len = -1 },
         };
         Ok::<(), mvcc_rs::errors::DatabaseError>(())
-    }) {
+    } {
         Ok(_) => {
             tracing::debug!("MVCCDatabaseRead: success");
             MVCCError::MVCC_OK
@@ -297,8 +275,7 @@ pub unsafe extern "C" fn MVCCScanCursorRead(
 
 #[no_mangle]
 pub unsafe extern "C" fn MVCCScanCursorNext(cursor: MVCCScanCursorRef) -> std::ffi::c_int {
-    let cursor_ctx = unsafe { &mut *cursor.ptr };
-    let cursor = &mut cursor_ctx.cursor;
+    let cursor = cursor.get_ref_mut();
     tracing::debug!("MVCCScanCursorNext(): {}", cursor.index);
     if cursor.forward() {
         tracing::debug!("Forwarded to {}", cursor.index);
@@ -311,8 +288,7 @@ pub unsafe extern "C" fn MVCCScanCursorNext(cursor: MVCCScanCursorRef) -> std::f
 
 #[no_mangle]
 pub unsafe extern "C" fn MVCCScanCursorPosition(cursor: MVCCScanCursorRef) -> u64 {
-    let cursor_ctx = unsafe { &mut *cursor.ptr };
-    let cursor = &mut cursor_ctx.cursor;
+    let cursor = cursor.get_ref();
     cursor
         .current_row_id()
         .map(|row_id| row_id.row_id)

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -17,14 +17,14 @@ impl MVCCDatabaseRef {
         self.ptr.is_null()
     }
 
-    pub fn get_ref(&self) -> &DbContext {
-        unsafe { &*(self.ptr) }
+    pub fn get_ref(&self) -> &Db {
+        &unsafe { &*(self.ptr) }.db
     }
 
     #[allow(clippy::mut_from_ref)]
-    pub fn get_ref_mut(&self) -> &mut DbContext {
+    pub fn get_ref_mut(&self) -> &mut Db {
         let ptr_mut = self.ptr as *mut DbContext;
-        unsafe { &mut (*ptr_mut) }
+        &mut unsafe { &mut (*ptr_mut) }.db
     }
 }
 
@@ -44,16 +44,36 @@ impl From<&mut DbContext> for MVCCDatabaseRef {
 
 pub struct DbContext {
     pub(crate) db: Db,
-    pub(crate) runtime: tokio::runtime::Runtime,
 }
 
 pub struct ScanCursorContext {
-    pub cursor: crate::ScanCursor,
-    pub db: MVCCDatabaseRef,
+    pub(crate) cursor: crate::ScanCursor,
 }
 
 #[derive(Clone, Debug)]
 #[repr(transparent)]
 pub struct MVCCScanCursorRef {
     pub ptr: *mut ScanCursorContext,
+}
+
+impl MVCCScanCursorRef {
+    pub fn null() -> MVCCScanCursorRef {
+        MVCCScanCursorRef {
+            ptr: std::ptr::null_mut(),
+        }
+    }
+
+    pub fn is_null(&self) -> bool {
+        self.ptr.is_null()
+    }
+
+    pub fn get_ref(&self) -> &crate::ScanCursor {
+        &unsafe { &*(self.ptr) }.cursor
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    pub fn get_ref_mut(&self) -> &mut crate::ScanCursor {
+        let ptr_mut = self.ptr as *mut ScanCursorContext;
+        &mut unsafe { &mut (*ptr_mut) }.cursor
+    }
 }

--- a/mvcc-rs/Cargo.toml
+++ b/mvcc-rs/Cargo.toml
@@ -5,19 +5,16 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.70"
-futures = "0.3.28"
 thiserror = "1.0.40"
 tracing = "0.1.37"
-tokio = { version = "1.27.0", features = ["full", "parking_lot"] }
-tokio-stream = { version = "0.1.12", features = ["io-util"] }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
-pin-project = "1.0.12"
 tracing-subscriber = { version = "0", optional = true }
 base64 = "0.21.0"
 aws-sdk-s3 = "0.27.0"
 aws-config = "0.55.2"
-tokio-util = "0.7.8"
+parking_lot = "0.12.1"
+futures = "0.3.28"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports", "async", "async_futures"] }

--- a/mvcc-rs/benches/my_benchmark.rs
+++ b/mvcc-rs/benches/my_benchmark.rs
@@ -17,30 +17,30 @@ fn bench(c: &mut Criterion) {
     let db = bench_db();
     group.bench_function("begin_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
-            db.begin_tx().await;
+            db.begin_tx();
         })
     });
 
     let db = bench_db();
     group.bench_function("begin_tx + rollback_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
-            let tx_id = db.begin_tx().await;
-            db.rollback_tx(tx_id).await
+            let tx_id = db.begin_tx();
+            db.rollback_tx(tx_id)
         })
     });
 
     let db = bench_db();
     group.bench_function("begin_tx + commit_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
-            let tx_id = db.begin_tx().await;
-            db.commit_tx(tx_id).await
+            let tx_id = db.begin_tx();
+            db.commit_tx(tx_id)
         })
     });
 
     let db = bench_db();
     group.bench_function("begin_tx-read-commit_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
-            let tx_id = db.begin_tx().await;
+            let tx_id = db.begin_tx();
             db.read(
                 tx_id,
                 RowID {
@@ -48,16 +48,15 @@ fn bench(c: &mut Criterion) {
                     row_id: 1,
                 },
             )
-            .await
             .unwrap();
-            db.commit_tx(tx_id).await
+            db.commit_tx(tx_id)
         })
     });
 
     let db = bench_db();
     group.bench_function("begin_tx-update-commit_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
-            let tx_id = db.begin_tx().await;
+            let tx_id = db.begin_tx();
             db.update(
                 tx_id,
                 Row {
@@ -68,15 +67,14 @@ fn bench(c: &mut Criterion) {
                     data: "World".to_string(),
                 },
             )
-            .await
             .unwrap();
-            db.commit_tx(tx_id).await
+            db.commit_tx(tx_id)
         })
     });
 
     let db = bench_db();
-    let tx = futures::executor::block_on(db.begin_tx());
-    futures::executor::block_on(db.insert(
+    let tx = db.begin_tx();
+    db.insert(
         tx,
         Row {
             id: RowID {
@@ -85,7 +83,7 @@ fn bench(c: &mut Criterion) {
             },
             data: "Hello".to_string(),
         },
-    ))
+    )
     .unwrap();
     group.bench_function("read", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
@@ -96,14 +94,13 @@ fn bench(c: &mut Criterion) {
                     row_id: 1,
                 },
             )
-            .await
             .unwrap();
         })
     });
 
     let db = bench_db();
-    let tx = futures::executor::block_on(db.begin_tx());
-    futures::executor::block_on(db.insert(
+    let tx = db.begin_tx();
+    db.insert(
         tx,
         Row {
             id: RowID {
@@ -112,7 +109,7 @@ fn bench(c: &mut Criterion) {
             },
             data: "Hello".to_string(),
         },
-    ))
+    )
     .unwrap();
     group.bench_function("update", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
@@ -126,7 +123,6 @@ fn bench(c: &mut Criterion) {
                     data: "World".to_string(),
                 },
             )
-            .await
             .unwrap();
         })
     });

--- a/mvcc-rs/src/cursor.rs
+++ b/mvcc-rs/src/cursor.rs
@@ -10,12 +10,12 @@ pub struct ScanCursor<'a, Clock: LogicalClock> {
 }
 
 impl<'a, Clock: LogicalClock> ScanCursor<'a, Clock> {
-    pub async fn new(
+    pub fn new(
         db: &'a Database<Clock>,
         tx_id: u64,
         table_id: u64,
     ) -> Result<ScanCursor<'a, Clock>> {
-        let row_ids = db.scan_row_ids_for_table(table_id).await?;
+        let row_ids = db.scan_row_ids_for_table(table_id)?;
         Ok(Self {
             db,
             tx_id,
@@ -31,15 +31,15 @@ impl<'a, Clock: LogicalClock> ScanCursor<'a, Clock> {
         Some(self.row_ids[self.index])
     }
 
-    pub async fn current_row(&self) -> Result<Option<Row>> {
+    pub fn current_row(&self) -> Result<Option<Row>> {
         if self.index >= self.row_ids.len() {
             return Ok(None);
         }
         let id = self.row_ids[self.index];
-        self.db.read(self.tx_id, id).await
+        self.db.read(self.tx_id, id)
     }
 
-    pub async fn close(self) -> Result<()> {
+    pub fn close(self) -> Result<()> {
         Ok(())
     }
 

--- a/mvcc-rs/tests/concurrency_test.rs
+++ b/mvcc-rs/tests/concurrency_test.rs
@@ -19,48 +19,44 @@ fn test_non_overlapping_concurrent_inserts() {
                 let db = db.clone();
                 let ids = ids.clone();
                 thread::spawn(move || {
-                    shuttle::future::block_on(async move {
-                        let tx = db.begin_tx().await;
-                        let id = ids.fetch_add(1, Ordering::SeqCst);
-                        let id = RowID {
-                            table_id: 1,
-                            row_id: id,
-                        };
-                        let row = Row {
-                            id,
-                            data: "Hello".to_string(),
-                        };
-                        db.insert(tx, row.clone()).await.unwrap();
-                        db.commit_tx(tx).await.unwrap();
-                        let tx = db.begin_tx().await;
-                        let committed_row = db.read(tx, id).await.unwrap();
-                        db.commit_tx(tx).await.unwrap();
-                        assert_eq!(committed_row, Some(row));
-                    })
+                    let tx = db.begin_tx();
+                    let id = ids.fetch_add(1, Ordering::SeqCst);
+                    let id = RowID {
+                        table_id: 1,
+                        row_id: id,
+                    };
+                    let row = Row {
+                        id,
+                        data: "Hello".to_string(),
+                    };
+                    db.insert(tx, row.clone()).unwrap();
+                    db.commit_tx(tx).unwrap();
+                    let tx = db.begin_tx();
+                    let committed_row = db.read(tx, id).unwrap();
+                    db.commit_tx(tx).unwrap();
+                    assert_eq!(committed_row, Some(row));
                 });
             }
             {
                 let db = db.clone();
                 let ids = ids.clone();
                 thread::spawn(move || {
-                    shuttle::future::block_on(async move {
-                        let tx = db.begin_tx().await;
-                        let id = ids.fetch_add(1, Ordering::SeqCst);
-                        let id = RowID {
-                            table_id: 1,
-                            row_id: id,
-                        };
-                        let row = Row {
-                            id,
-                            data: "World".to_string(),
-                        };
-                        db.insert(tx, row.clone()).await.unwrap();
-                        db.commit_tx(tx).await.unwrap();
-                        let tx = db.begin_tx().await;
-                        let committed_row = db.read(tx, id).await.unwrap();
-                        db.commit_tx(tx).await.unwrap();
-                        assert_eq!(committed_row, Some(row));
-                    });
+                    let tx = db.begin_tx();
+                    let id = ids.fetch_add(1, Ordering::SeqCst);
+                    let id = RowID {
+                        table_id: 1,
+                        row_id: id,
+                    };
+                    let row = Row {
+                        id,
+                        data: "World".to_string(),
+                    };
+                    db.insert(tx, row.clone()).unwrap();
+                    db.commit_tx(tx).unwrap();
+                    let tx = db.begin_tx();
+                    let committed_row = db.read(tx, id).unwrap();
+                    db.commit_tx(tx).unwrap();
+                    assert_eq!(committed_row, Some(row));
                 });
             }
         },


### PR DESCRIPTION
We dropped all occurrences of Tokio to avoid the cost of allocations induced by async runtimes.
The only async part of the code is now S3 storage, which is just wrapped in a futures::executor::block_on()