### PR TITLE
database: drop the mutex

### DIFF
--- a/mvcc-rs/src/database/tests.rs
+++ b/mvcc-rs/src/database/tests.rs
@@ -337,7 +337,6 @@ fn test_dirty_read() {
     assert_eq!(row2, None);
 }
 
-#[ignore]
 #[traced_test]
 #[test]
 fn test_dirty_read_deleted() {

--- a/mvcc-rs/src/persistent_storage/mod.rs
+++ b/mvcc-rs/src/persistent_storage/mod.rs
@@ -27,7 +27,7 @@ impl Storage {
 }
 
 impl Storage {
-    pub fn log_tx(&mut self, m: LogRecord) -> Result<()> {
+    pub fn log_tx(&self, m: LogRecord) -> Result<()> {
         match self {
             Self::JsonOnDisk(path) => {
                 use std::io::Write;


### PR DESCRIPTION
Without a critical section, we naturally hit a few unimplemented paths when handling concurrent transactions, which is great news! Visiting previously impossible paths already proves that lock-free is able to handle concurrency > 1.
Now, the easy part - fixing all the unimplemented paths and making the Hekaton implementation 100% foolproof.