### PR TITLE
concurrency test: port to OS threads

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_LOG: info,mvcc_rs=trace
 
 jobs:
   build:

--- a/mvcc-rs/Cargo.toml
+++ b/mvcc-rs/Cargo.toml
@@ -16,13 +16,12 @@ aws-config = "0.55.2"
 parking_lot = "0.12.1"
 futures = "0.3.28"
 crossbeam-skiplist = "0.1.1"
+tracing-test = "0"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports", "async", "async_futures"] }
 pprof = { version = "0.11.1", features = ["criterion", "flamegraph"] }
-shuttle = "0.6.0"
 tracing-subscriber = "0"
-tracing-test = "0"
 mvcc-rs = { path = "." }
 
 [[bench]]

--- a/mvcc-rs/src/database/mod.rs
+++ b/mvcc-rs/src/database/mod.rs
@@ -440,7 +440,7 @@ impl<Clock: LogicalClock> Database<Clock> {
         let tx_id = self.get_tx_id();
         let begin_ts = self.get_timestamp();
         let tx = Transaction::new(tx_id, begin_ts);
-        tracing::trace!("BEGIN    {tx}");
+        tracing::trace!("BEGIN     {tx}");
         self.txs.insert(tx_id, RwLock::new(tx));
         tx_id
     }
@@ -565,6 +565,7 @@ impl<Clock: LogicalClock> Database<Clock> {
                 }
             }
         }
+        tracing::trace!("UPDATED   {tx}");
         // We have now updated all the versions with a reference to the
         // transaction ID to a timestamp and can, therefore, remove the
         // transaction. Please note that when we move to lockless, the
@@ -577,6 +578,7 @@ impl<Clock: LogicalClock> Database<Clock> {
         if !log_record.row_versions.is_empty() {
             self.storage.log_tx(log_record)?;
         }
+        tracing::trace!("LOGGED    {tx}");
         Ok(())
     }
 


### PR DESCRIPTION
Without mutexes, it makes no sense anymore to use shuttle.
Instead, the test cases just spawn OS threads.

Also, a case with overlapping ids is added, to test whether
transactions read their own writes within the same transaction.